### PR TITLE
Update front page: shorten "speaking info" and add link to CFP page

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,10 +61,8 @@
     <div class="item-50 item-content">
       <h1>Speaking at JSConf EU</h1>
       <p>
-        We are inviting the JavaScript community to submit talks for the upcoming JSConf EU, and will open our Call for Presentations in March. If you think you have something great to talk about, you should consider submitting your idea. Here’s a resource to remind you <a href="http://weareallaweso.me/" target="_blank">why you should become a speaker</a>, and here are some tips on <a href="http://2014.cssconf.eu/news/how-to-write-a-great-talk-proposal-for-a-tech" target="_blank">how to write a great proposal</a>.
+        Thank you for your submissions! Our <a href="/call-for-speakers">call for speakers</a> ended on January 10. Now we are busy reading through your proposals...
       </p>
-      <p>The call for speakers closed on January 10th.</p>
-
     </div>
 
   </div>


### PR DESCRIPTION
I hope I did this right, I'm not very experienced with pull requests yet.
BTW the text before this commit was still wrong (it talks about the CfP ending in March)