### PR TITLE
Fix combo ticket link in teaser

### DIFF
--- a/_posts/2017-02-10-tickets-update.md
+++ b/_posts/2017-02-10-tickets-update.md
@@ -8,4 +8,4 @@ figure: /img/what-next.jpg
 
 {% include post-header.html %}
 
-Tickets are coming back on sale on March 9th. [Details over here](/news/2016/11/29/tickets/) or [purchase a combo ticket]((https://ti.to/jsconfeu/jsconfeu2017)) with [CSSConf EU](http://2017.cssconf.eu/) today.
+Tickets are coming back on sale on March 9th. [Details over here](/news/2016/11/29/tickets/) or [purchase a combo ticket](https://ti.to/jsconfeu/jsconfeu2017) with [CSSConf EU](http://2017.cssconf.eu/) today.


### PR DESCRIPTION
Looks like the extra parentheses previously caused this to render as follows:

```html
<a href="(https://ti.to/jsconfeu/jsconfeu2017)">purchase a combo ticket</a>
```

### Before

![screen shot 2017-03-09 at 16 46 38](https://cloud.githubusercontent.com/assets/352105/23757922/6fc4ebe6-04e8-11e7-9543-869e9b91ba1b.png)

http://2017.jsconf.eu/(https://ti.to/jsconfeu/jsconfeu2017)
(leads to a 404)

### After

![screen shot 2017-03-09 at 16 47 35](https://cloud.githubusercontent.com/assets/352105/23757941/7b03e9a8-04e8-11e7-9e45-4329d83d9c2d.png)

https://ti.to/jsconfeu/jsconfeu2017