### PR TITLE
Add content for neighbourhoodie sponsorship page

### DIFF
--- a/sponsors/_posts/2017-04-16-hoodie.md
+++ b/sponsors/_posts/2017-04-16-hoodie.md
@@ -2,9 +2,14 @@
 layout: sponsor-page
 tags: sponsor
 level: a-sponsor-special
-title: Hoodie
+title: Neighbourhoodie
 permalink: "/sponsors/hoodie.html"
 image: "/sponsors/images/hoodie.svg"
-link: "http://hood.ie"
+link: "http://neighbourhood.ie"
 priority: 3
 ---
+We build [Greenkeeper](https://greenkeeper.io) and [Hoodie](https://hood.ie), drive the [Offline First](https://offlinefirst.org) initiative and work for and with [CouchDB](https://couchdb.com) and [PouchDB](https://pouchdb.com).
+
+We help design and build Offline First web apps, and offer a range of support and consultation services around [CouchDB](https://couchdb.com) and [PouchDB](https://pouchdb.com).
+
+Stop by our booth to find out more!


### PR DESCRIPTION
The page was missing content and linking to the wrong place. It now looks like this:

![bildschirmfoto 2017-04-27 um 10 13 38](https://cloud.githubusercontent.com/assets/391124/25474122/45107dbe-2b32-11e7-9fd6-5d7db9c3648a.png)

cc. @janl 