### PR TITLE
Fix URL for raw schedule JSON feed

### DIFF
--- a/_posts/2017-05-01-schedule.md
+++ b/_posts/2017-05-01-schedule.md
@@ -15,4 +15,3 @@ Choose your favorite version of our [time table](https://jsconf.philna.sh), or m
 - [Google Doc \(Consider marking as offline available\)](https://docs.google.com/spreadsheets/d/1kjFshBwdJzAz4IT-02ZTPUTtQYYl4zk9IxuwsohOTos/edit?ts=58f7c042#gid=1853717256)
 <!--- If the JSON link below doesn’t work, try following these instructions: http://stackoverflow.com/a/24535246 --->
 - We'd appreciate prettier, mobile friendly, offline capable versions. Here is the raw data: [Crappy XML-identity-crisis JSON](https://spreadsheets.google.com/feeds/cells/1kjFshBwdJzAz4IT-02ZTPUTtQYYl4zk9IxuwsohOTos/default/public/basic?alt=json). [JS sample to parse JSON into digestible format, see console](https://gist.github.com/usefulthink/ebf60a0df6732fa0a91ab0569fa39a2e).
-- A really good one by

--- a/_posts/2017-05-01-schedule.md
+++ b/_posts/2017-05-01-schedule.md
@@ -13,5 +13,6 @@ Choose your favorite version of our [time table](https://jsconf.philna.sh), or m
 - ___[Formatted web version](https://jsconf.philna.sh)___ (Contributed by Phil Nash)
 - ___[HTML version](https://docs.google.com/spreadsheets/d/1kjFshBwdJzAz4IT-02ZTPUTtQYYl4zk9IxuwsohOTos/pubhtml)___
 - [Google Doc \(Consider marking as offline available\)](https://docs.google.com/spreadsheets/d/1kjFshBwdJzAz4IT-02ZTPUTtQYYl4zk9IxuwsohOTos/edit?ts=58f7c042#gid=1853717256)
-- We'd appreciate prettier, mobile friendly, offline capable versions. Here is the raw data: [Crappy XML-identity-crisis JSON](https://spreadsheets.google.com/feeds/cells/1kjFshBwdJzAz4IT-02ZTPUTtQYYl4zk9IxuwsohOTos/od4/public/basic?alt=json). [JS sample to parse JSON into digestible format, see console](https://gist.github.com/usefulthink/ebf60a0df6732fa0a91ab0569fa39a2e).
+<!--- If the JSON link below doesn’t work, try following these instructions: http://stackoverflow.com/a/24535246 --->
+- We'd appreciate prettier, mobile friendly, offline capable versions. Here is the raw data: [Crappy XML-identity-crisis JSON](https://spreadsheets.google.com/feeds/cells/1kjFshBwdJzAz4IT-02ZTPUTtQYYl4zk9IxuwsohOTos/default/public/basic?alt=json). [JS sample to parse JSON into digestible format, see console](https://gist.github.com/usefulthink/ebf60a0df6732fa0a91ab0569fa39a2e).
 - A really good one by


### PR DESCRIPTION
The previous feed URL recently started returning the following error:

```
< HTTP/1.1 400 Bad Request
Invalid query parameter value for grid_id.
```

This commit updates the grid_id parameter in the URL from `od4` to `default`,
which appears to work consistently. It also adds a code comment to help people
fix it in the future in case the URL breaks again — though hopefully it won’t!

### References

“Google Docs Spreadsheet to JSON” on StackOverflow:
http://stackoverflow.com/questions/23641492/google-docs-spreadsheet-to-json/26774243#26774243

The previous feed URL, which currently returns a 400:
https://spreadsheets.google.com/feeds/cells/1kjFshBwdJzAz4IT-02ZTPUTtQYYl4zk9IxuwsohOTos/od4/public/basic?alt=json

Also, JSConf EU + CSSConf EU were both amazing. ❤️ 